### PR TITLE
Add Support for RSS

### DIFF
--- a/GameData/KerbalGPS/Contracts/GNSS/Kerbin-GNSS.cfg
+++ b/GameData/KerbalGPS/Contracts/GNSS/Kerbin-GNSS.cfg
@@ -75,13 +75,15 @@ CONTRACT_TYPE
 	{
 		type = double
 		
-		minAp = 0.995 * @targetHeight
+		// Kerbal Space Program just has to switch between measuring from the surface and the center
+		minAp = 0.995 * @targetHeight - HomeWorld().Radius()
 	}
 	DATA
 	{
 		type = double
 		
-		maxAp = 1.005 * @targetHeight
+		// Kerbal Space Program just has to switch between measuring from the surface and the center
+		maxAp = 1.005 * @targetHeight - HomeWorld().Radius()
 	}
 	
 	DATA
@@ -120,13 +122,15 @@ CONTRACT_TYPE
 	{
 		type = double
 		
-		minPe = 0.995 * @resonantPeri
+		// Kerbal Space Program just has to switch between measuring from the surface and the center
+		minPe = 0.995 * @resonantPeri - HomeWorld().Radius()
 	}
 	DATA
 	{
 		type = double
 		
-		maxPe = 1.005 * @resonantPeri
+		// Kerbal Space Program just has to switch between measuring from the surface and the center
+		maxPe = 1.005 * @resonantPeri - HomeWorld().Radius()
 	}
 	
 	DATA

--- a/GameData/KerbalGPS/Contracts/GNSS/Kerbin-GNSS.cfg
+++ b/GameData/KerbalGPS/Contracts/GNSS/Kerbin-GNSS.cfg
@@ -1,9 +1,10 @@
-// Contract for setting up a Kerbin GNSS network.
+// Contract for setting up a GNSS network around the homeworld.
 //   Author: nightingale
 
 // Typos fixed by LGG
 // Updated to use HomeWorld instead of Kerbin
-// This assumes that any homeworld is the same size as Kerbin
+
+// Adapted to arbitrary homeworld sizes by Jarred Allen
 
 CONTRACT_TYPE
 {
@@ -11,7 +12,7 @@ CONTRACT_TYPE
     group = GNSS
 
     title = Create a @/planet Global Navigation Satellite System.
-    genericTitle = Create a Global Navigation Satellite System.
+    genericTitle = Create a Global Navigation Satellite System for @/planet.
     description = From time immemorial, Kerbalosiphers have looked to answer the question, "Where are we going?"  But to be able to know where we're going, we first need to figure out where we are.
     synopsis = Launch a network of 18 GNSS satellites.
     completedMessage = The network is up and transmitting, good work!
@@ -19,7 +20,7 @@ CONTRACT_TYPE
     // Level 2 prestige
     prestige = Significant
 
-    // This is definitely a Kerbin contract
+    // This is definitely a Homeworld contract
     targetBody = @/planet
 
     // Always offered by the R&D department
@@ -36,7 +37,104 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = CelestialBody
+		
 		planet = HomeWorld()
+	}
+	
+	DATA 
+	{
+		type = double
+		
+		// The desired orbital period
+		orbitT = HomeWorld().RotationalPeriod()/2
+	}
+	
+	DATA
+	{
+		type = double
+		
+		G = 0.0000000000667408
+	}
+	
+	DATA
+	{
+		type = double
+		
+		// The height of the target orbit for the satellites
+		targetHeight = Pow(HomeWorld().Mass()*@G*0.02533030 * Pow(@orbitT, 2), 1/3)
+	}
+	
+	DATA
+	{
+		type = double
+		
+		// Defined here for representing it to the user
+		targetHeightKm = Round(@targetHeight / 1000, 1.0)
+	}
+	DATA
+	{
+		type = double
+		
+		minAp = 0.995 * @targetHeight
+	}
+	DATA
+	{
+		type = double
+		
+		maxAp = 1.005 * @targetHeight
+	}
+	
+	DATA
+	{
+		type = double
+		
+		// The orbital period of the resonant orbit for injecting the satellites.
+		resonantT = @orbitT *5/6
+	}
+	
+	DATA
+	{
+		type = double
+		
+		// The semi-major axis of the resonant orbit
+		resonantSMA = Pow(HomeWorld().Mass()*@G*0.02533030 * Pow(@resonantT, 2), 1/3)
+	}
+	
+	DATA
+	{
+		type = double
+		
+		// The periapsis height of the resonant orbit
+		resonantPeri = @resonantSMA * 2 - @targetHeight
+	}
+	
+	DATA
+	{
+		type = double
+	
+		// Defined here for representing it to the user
+		resonantPeriKm = Round(@resonantPeri / 1000, 1.0)
+	}
+	
+	DATA
+	{
+		type = double
+		
+		minPe = 0.995 * @resonantPeri
+	}
+	DATA
+	{
+		type = double
+		
+		maxPe = 1.005 * @resonantPeri
+	}
+	
+	DATA
+	{
+		type = double
+		
+		// Wait duration for the WaitTwoOrbits parameter
+		waitDuration = resonantT*1.99
 	}
 
     PARAMETER
@@ -53,7 +151,7 @@ CONTRACT_TYPE
             name = GNSSLauncher
             type = VesselParameterGroup
 
-            title = Put a 3 satellite launcher into a 1088 km x 1588 km orbit
+            title = Put a 3 satellite launcher into a @/resonantPeriKm km x @/targetHeightKm km orbit
 
             PARAMETER
             {
@@ -69,13 +167,13 @@ CONTRACT_TYPE
                 name = Orbit
                 type = Orbit
 
-                // 1088 km +/- 0.5 %
-                minPeA = 1082560
-                maxPeA = 1093440
+                // Resonant Periapsis Height +/- 0.5 %
+                minPeA = @/minPe
+                maxPeA = @/maxPe
 
-                // 1588 km +/- 0.5 %
-                minApA = 1580060
-                maxApA = 1595940
+                // Target Height +/- 0.5 %
+                minApA = @/minAp
+                maxApA = @/maxAp
 
                 // Pretty close to equatorial
                 maxInclination = 0.5
@@ -115,9 +213,8 @@ CONTRACT_TYPE
             name = WaitTwoOrbits
             type = Duration
 
-            // We cut off 42 seconds to give a round number and give the player
-            // buffer if their orbit isn't perfect
-            duration = 5h
+            // We cut off 1% of the time to give the player buffer if their orbit isn't perfect
+            duration = @/waitDuration
 
             preWaitText = Wait two orbits between satellites:
             waitingText =  Wait two orbits between satellites:
@@ -165,9 +262,8 @@ CONTRACT_TYPE
             name = WaitTwoOrbits
             type = Duration
 
-            // We cut off 42 seconds to give a round number and give the player
-            // buffer if their orbit isn't perfect
-            duration = 5h
+            // We cut off 1% of the time to give the player buffer if their orbit isn't perfect
+            duration = @/waitDuration
 
             preWaitText = Wait two orbits between satellites:
             waitingText =  Wait two orbits between satellites:
@@ -788,7 +884,7 @@ CONTRACT_TYPE
         {
             ORBIT
             {
-                SMA = 2188000
+                SMA = @/targetHeight
                 ECC = 0
                 INC = 0
                 LPE = 0
@@ -803,7 +899,7 @@ CONTRACT_TYPE
         {
             ORBIT
             {
-                SMA = 2188000
+                SMA = @/targetHeight
                 ECC = 0
                 INC = 60
                 LPE = 0
@@ -818,7 +914,7 @@ CONTRACT_TYPE
         {
             ORBIT
             {
-                SMA = 2188000
+                SMA = @/targetHeight
                 ECC = 0
                 INC = 60
                 LPE = 0
@@ -833,7 +929,7 @@ CONTRACT_TYPE
         {
             ORBIT
             {
-                SMA = 2188000
+                SMA = @/targetHeight
                 ECC = 0
                 INC = 60
                 LPE = 0
@@ -848,7 +944,7 @@ CONTRACT_TYPE
         {
             ORBIT
             {
-                SMA = 2188000
+                SMA = @/targetHeight
                 ECC = 0
                 INC = 60
                 LPE = 0
@@ -863,7 +959,7 @@ CONTRACT_TYPE
         {
             ORBIT
             {
-                SMA = 2188000
+                SMA = @/targetHeight
                 ECC = 0
                 INC = 60
                 LPE = 0

--- a/GameData/KerbalGPS/Parts/FigaroTransmitter/FigaroTransmitter.cfg
+++ b/GameData/KerbalGPS/Parts/FigaroTransmitter/FigaroTransmitter.cfg
@@ -47,3 +47,9 @@ PART
 		}
 	}
 }
+
+@PART[FigaroTransmitter]:NEEDS[RealSolarSystem] {	
+	@MODULE[ModuleGPSTransmitter] {
+		@gpsRange = 25000000
+	}
+}


### PR DESCRIPTION
I modified the mod to correctly handle RSS, at least for Earth. The only tweaks I made were having it dynamically generate orbit sizes in the homeworld contract (to place the resulting constellation into a semi-synchronous orbit) and multiply the transmitter range tenfold if the user is playing on RSS.

Note that the antenna range is just hardcoded to change for RSS, so the antenna won't reach far enough for Real-Scale Stock Solar System and other similar planet packs.