### PR TITLE
make the RSS patch generic

### DIFF
--- a/GameData/KerbalGPS/Parts/FigaroTransmitter/FigaroTransmitter.cfg
+++ b/GameData/KerbalGPS/Parts/FigaroTransmitter/FigaroTransmitter.cfg
@@ -48,8 +48,3 @@ PART
 	}
 }
 
-@PART[FigaroTransmitter]:NEEDS[RealSolarSystem] {	
-	@MODULE[ModuleGPSTransmitter] {
-		@gpsRange = 25000000
-	}
-}

--- a/GameData/KerbalGPS/Patches/KerbalGPS_RSS.cfg
+++ b/GameData/KerbalGPS/Patches/KerbalGPS_RSS.cfg
@@ -1,0 +1,6 @@
+@PART[*]:HAS[@MODULE[ModuleGPSTransmitter]]:NEEDS[RealSolarSystem]:AFTER[KerbalGPS]
+{	
+	@MODULE[ModuleGPSTransmitter] {
+		@gpsRange *= 10
+	}
+}

--- a/GameData/KerbalGPS/Patches/KerbalGPS_SigmaDimensions.cfg
+++ b/GameData/KerbalGPS/Patches/KerbalGPS_SigmaDimensions.cfg
@@ -1,0 +1,7 @@
+@PART[*]:HAS[@MODULE[ModuleGPSTransmitter]]:NEEDS[SigDim]:AFTER[KerbalGPS]
+{	
+	@MODULE[ModuleGPSTransmitter]
+	{
+		@gpsRange *= #$@SigmaDimensions/Rescale$
+	}
+}


### PR DESCRIPTION
Instead of placing the RSS scale patch directly into the config of the FigaroTransmitter, place it into a generic patch to also rescale the ModuleGPSTransmitter for other parts that added it.

Supports yet:
RealSolarSystem
SigmaDimensions